### PR TITLE
Fix context menu search loop

### DIFF
--- a/modules/client-emulator.js
+++ b/modules/client-emulator.js
@@ -258,10 +258,11 @@ module.exports = class HabboClient {
       } else {
         // fallback: click their last bubble
         const bubbles = await nitroFrame.$$(`.bubble-container.visible .username strong`);
-        const match = bubbles.reverse().find(async s => {
+        let match = null;
+        for (const s of bubbles.reverse()) {
           const txt = (await (await s.getProperty('textContent')).jsonValue()).trim();
-          return txt === target;
-        });
+          if (txt === target) { match = s; break; }
+        }
         if (!match) throw new Error(`No bubble found for ${target}`);
         await nitroFrame.evaluate(el => el.closest('.bubble-container.visible').click(), match);
       }

--- a/modules/ui-mapper.js
+++ b/modules/ui-mapper.js
@@ -174,4 +174,4 @@ async sendChat(page, text) {
   }
 };
 
-// Need to fix the agent going to the hotel view button
+// TODO: prevent agent from clicking the hotel view button


### PR DESCRIPTION
## Summary
- fix async `.find` bug when locating user's bubble in `performSocialAction`
- clean up comment and newline in `ui-mapper`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841c6262ec4832cb39cd6a301ebb4ab