### PR TITLE
Enable wallet sharing and token transfers

### DIFF
--- a/modules/aiModule.js
+++ b/modules/aiModule.js
@@ -25,7 +25,7 @@ function randomBetween(a, b) {
 
 // ── leak-filter helper ───────────────────────────
 const LEAK_REGEX =
-  /(core philosophy|current feeling|practical skills|personal goals|emotional tones|memory:|beliefs \(top3\)|recent routine|style examples)/i;
+  /(core philosophy|current feeling|practical skills|personal goals|emotional tones|memory:|beliefs \(top3\)|recent routine|style examples|^analysis:|^summary:|^notes?:|^thoughts?:|^observation:)/i;
 
 function sanitizeLLMReply(txt) {
   return txt

--- a/satellite-v8.js
+++ b/satellite-v8.js
@@ -243,6 +243,129 @@ function makeSnapshot({ emotion, traits, beliefs, wallet }) {
   };
 }
 
+// Room-Change Negotiation Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan “All Rooms” and return an array like:
+ *   [{ name, count, handle }]
+ * Runs on the main page (no frames involved).
+ */
+async function scanRooms(client) {
+  const page = client.page;
+  console.log('[scanRooms] Opening Rooms menu…');
+  await page.click('.navigation-item.icon.icon-rooms');
+
+  // Wait for the navigator panel to appear
+  await page.waitForSelector(
+    '.draggable-window .nitro-navigator',
+    { visible: true, timeout: 5000 }
+  );
+
+  console.log('[scanRooms] Clicking All Rooms tab…');
+  await page.click('.draggable-window .icon-naviallrooms');
+
+  // Wait for room list items
+  await page.waitForSelector(
+    '.draggable-window .navigator-item',
+    { timeout: 5000 }
+  );
+
+  // Collect all navigator-item elements
+  const els = await page.$$('.draggable-window .navigator-item');
+  console.log(`[scanRooms] Found ${els.length} rooms`);
+
+  if (els.length === 0) {
+    throw new Error('No rooms detected after clicking All Rooms');
+  }
+
+  // Extract room name and occupancy badge
+  return Promise.all(
+    els.map(async el => {
+      const name  = await el.$eval('.text-truncate', n => n.textContent.trim());
+      const badge = await el.$eval('.badge', b => b.textContent.trim())
+                            .catch(() => '0');
+      return {
+        name,
+        count: parseInt(badge, 10) || 0,
+        handle: el
+      };
+    })
+  );
+}
+
+/**
+ * Negotiate a move: choose an empty room or click the “Somewhere new” button.
+ * Retries once on error.
+ */
+async function negotiateRoomChange(client, partnerName) {
+  const page = client.page;
+
+  // One full attempt wrapper
+  const attempt = async () => {
+    // 20% chance to click the “Somewhere new” button
+    if (Math.random() < 0.2) {
+      console.log('[negotiate] Taking “Somewhere new” branch');
+      const btns = await page.$$('.nav-bottom .nav-bottom-buttons-text');
+      for (const btn of btns) {
+        const txt = await page.evaluate(el => el.textContent.trim(), btn);
+        if (txt === 'Somewhere new') {
+          await btn.click();
+          return true;
+        }
+      }
+    }
+
+    console.log('[negotiate] Scanning rooms…');
+    const rooms = await scanRooms(client);
+
+    // Pick the first empty room
+    const empty = rooms.find(r => r.count === 0);
+    if (!empty) {
+      console.warn('[negotiate] No empty rooms — retrying with random');
+      return negotiateRoomChange(client, partnerName); // recursive retry
+    }
+
+    console.log(`[negotiate] Proposing to meet in "${empty.name}"`);
+    await client.sendChat(`@${partnerName} meet me in "${empty.name}"`);
+
+    // Immediately enter the room
+    console.log(`[negotiate] Entering "${empty.name}" now`);
+    await empty.handle.click();
+    await client.sendChat('Hello room! Anyone here?');
+    await movement.walkPath(client.page, ['down', 'down', 'right', 'right']);
+
+    if (partnerName) {
+      await client.sendChat(`@${partnerName} I’m here, let’s continue!`);
+    }
+
+    // Poll to see if partner arrives
+    for (let i = 0; i < 90; i++) {
+      await new Promise(r => setTimeout(r, 1000));
+      const fresh = (await scanRooms(client)).find(r => r.name === empty.name);
+      if (fresh && fresh.count > 0) {
+        console.log(`[negotiate] Partner joined "${empty.name}"`);
+        break;
+      }
+    }
+
+    return true;
+  };
+
+  // Try once; on failure retry once more
+  try {
+    return await attempt();
+  } catch (err) {
+    console.error('[negotiate] Error, retrying:', err.message);
+    try {
+      return await attempt();
+    } catch (err2) {
+      console.error('[negotiate] Second attempt failed:', err2.message);
+      return false;
+    }
+  }
+}
+
 /**
  * Main message handling: turn-lock → load memory → LLM → respond → cleanup.
  */
@@ -394,10 +517,48 @@ async function handleMessage(cfg, client, sender, text) {
         );
 
         reply = `✅ Trade ${action} executed: ${signature}`;
-      } catch (err) {
-        reply = `❌ Trading error: ${err.message}`;
-      }
+
+    } catch (err) {
+      reply = `❌ Trading error: ${err.message}`;
     }
+  }
+
+  // "!wallet" command block
+  if (text.trim() === '!wallet') {
+    const addr = profile.solanaKeypair.publicKey.toBase58();
+    reply = `My wallet: ${addr}`;
+  }
+
+  // "!send" command block
+  if (text.startsWith('!send ')) {
+    try {
+      // Usage: !send TOKEN_MINT AMOUNT DEST_PUBLIC_KEY
+      const parts = text.trim().split(/\s+/);
+      const mint  = parts[1];
+      const amt   = parseInt(parts[2], 10);
+      const dest  = parts[3];
+
+      if (!mint || isNaN(amt) || !dest) {
+        throw new Error('Usage: !send <TOKEN_MINT> <amount> <DEST_PUBLIC_KEY>');
+      }
+
+      const connection = new (require('@solana/web3.js').Connection)(
+        'https://api.devnet.solana.com'
+      );
+
+      const sig = await trade.trader.sendTokens(
+        connection,
+        profile.solanaKeypair,
+        mint,
+        dest,
+        amt * 10 ** 9
+      );
+
+      reply = `✅ Sent ${amt} of ${mint} → ${dest} (${sig})`;
+    } catch (err) {
+      reply = `❌ Send error: ${err.message}`;
+    }
+  }
 
     // Extract “real” topics from the user’s text
     const topics = extractTopics(text, { lang: 'en' });
@@ -619,129 +780,6 @@ async function handleMessage(cfg, client, sender, text) {
 
       await client.handleIncomingFriendRequest();
       await sleep(3000);
-    }
-
-    // Room-Change Negotiation Helpers
-    // -------------------------------------------------------------------------
-
-    /**
-     * Scan “All Rooms” and return an array like:
-     *   [{ name, count, handle }]
-     * Runs on the main page (no frames involved).
-     */
-    async function scanRooms(client) {
-      const page = client.page;
-      console.log('[scanRooms] Opening Rooms menu…');
-      await page.click('.navigation-item.icon.icon-rooms');
-
-      // Wait for the navigator panel to appear
-      await page.waitForSelector(
-        '.draggable-window .nitro-navigator',
-        { visible: true, timeout: 5000 }
-      );
-
-      console.log('[scanRooms] Clicking All Rooms tab…');
-      await page.click('.draggable-window .icon-naviallrooms');
-
-      // Wait for room list items
-      await page.waitForSelector(
-        '.draggable-window .navigator-item',
-        { timeout: 5000 }
-      );
-
-      // Collect all navigator-item elements
-      const els = await page.$$('.draggable-window .navigator-item');
-      console.log(`[scanRooms] Found ${els.length} rooms`);
-
-      if (els.length === 0) {
-        throw new Error('No rooms detected after clicking All Rooms');
-      }
-
-      // Extract room name and occupancy badge
-      return Promise.all(
-        els.map(async el => {
-          const name  = await el.$eval('.text-truncate', n => n.textContent.trim());
-          const badge = await el.$eval('.badge', b => b.textContent.trim())
-                                .catch(() => '0');
-          return {
-            name,
-            count: parseInt(badge, 10) || 0,
-            handle: el
-          };
-        })
-      );
-    }
-
-    /**
-     * Negotiate a move: choose an empty room or click the “Somewhere new” button.
-     * Retries once on error.
-     */
-    async function negotiateRoomChange(client, partnerName) {
-      const page = client.page;
-
-      // One full attempt wrapper
-      const attempt = async () => {
-        // 20% chance to click the “Somewhere new” button
-        if (Math.random() < 0.2) {
-          console.log('[negotiate] Taking “Somewhere new” branch');
-          const btns = await page.$$('.nav-bottom .nav-bottom-buttons-text');
-          for (const btn of btns) {
-            const txt = await page.evaluate(el => el.textContent.trim(), btn);
-            if (txt === 'Somewhere new') {
-              await btn.click();
-              return true;
-            }
-          }
-        }
-
-        console.log('[negotiate] Scanning rooms…');
-        const rooms = await scanRooms(client);
-
-        // Pick the first empty room
-        const empty = rooms.find(r => r.count === 0);
-        if (!empty) {
-          console.warn('[negotiate] No empty rooms — retrying with random');
-          return negotiateRoomChange(client, partnerName); // recursive retry
-        }
-
-        console.log(`[negotiate] Proposing to meet in "${empty.name}"`);
-        await client.sendChat(`@${partnerName} meet me in "${empty.name}"`);
-
-        // Immediately enter the room
-        console.log(`[negotiate] Entering "${empty.name}" now`);
-        await empty.handle.click();
-        await client.sendChat('Hello room! Anyone here?');
-        await movement.walkPath(client.page, ['down', 'down', 'right', 'right']);
-
-        if (partnerName) {
-          await client.sendChat(`@${partnerName} I’m here, let’s continue!`);
-        }
-
-        // Poll to see if partner arrives
-        for (let i = 0; i < 90; i++) {
-          await new Promise(r => setTimeout(r, 1000));
-          const fresh = (await scanRooms(client)).find(r => r.name === empty.name);
-          if (fresh && fresh.count > 0) {
-            console.log(`[negotiate] Partner joined "${empty.name}"`);
-            break;
-          }
-        }
-
-        return true;
-      };
-
-      // Try once; on failure retry once more
-      try {
-        return await attempt();
-      } catch (err) {
-        console.error('[negotiate] Error, retrying:', err.message);
-        try {
-          return await attempt();
-        } catch (err2) {
-          console.error('[negotiate] Second attempt failed:', err2.message);
-          return false;
-        }
-      }
     }
   } catch (err) {
     console.error(`[${cfg.username}] handleMessage error:`, err);


### PR DESCRIPTION
## Summary
- filter out analysis/summary lines from LLM replies
- add token transfer helper in `Trader`
- support `!wallet` and `!send` chat commands

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8b324840832c96e84b90ad68240c